### PR TITLE
Documentation capturing enablement of NFD-Topology-Updater in NFD

### DIFF
--- a/docs/advanced/developer-guide.md
+++ b/docs/advanced/developer-guide.md
@@ -275,6 +275,72 @@ stand-alone directly with `docker run`. See the
 [template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker-daemonset.yaml.template)
 for up-to-date information about the required volume mounts.
 
+
+### NFD-Topology-Updater
+
+In order to run nfd-topology as a "stand-alone" container against your
+standalone nfd-master you need to run them in the same network namespace:
+
+```bash
+$ docker run --rm --network=container:nfd-test ${NFD_CONTAINER_IMAGE} nfd-topology-updater
+2019/02/01 14:48:56 Node Feature Discovery Topology Updater <NFD_VERSION>
+...
+```
+
+If you just want to try out feature discovery without connecting to nfd-master,
+pass the `--no-publish` flag to nfd-worker.
+
+Command line flags of nfd-worker:
+
+```bash
+$ docker run --rm ${NFD_CONTAINER_IMAGE} nfd-topology-updater --help
+...
+nfd-topology-updater.
+
+  Usage:
+  nfd-topology-updater [--no-publish][--oneshot | --sleep-interval=<seconds>][--server=<server>]
+                       [--server-name-override=<name>] [--ca-file=<path>] [--cert-file=<path>]
+                       [--key-file=<path>][--container-runtime=<runtime>] [--podresources-socket=<path>]
+                       [--watch-namespace=<namespace>] [--sysfs=<mountpoint>] [--kubelet-config-file=<path>]
+  nfd-topology-updater -h | --help
+  nfd-topology-updater --version
+
+  Options:
+  -h --help                       Show this screen.
+  --version                       Output version and exit.
+  --ca-file=<path>                Root certificate for verifying connections
+                                  [Default: ]
+  --cert-file=<path>              Certificate used for authenticating connections
+                                  [Default: ]
+  --key-file=<path>               Private key matching --cert-file
+                                  [Default: ]
+  --server=<server>               NFD server address to connect to.
+                                  [Default: localhost:8080]
+  --server-name-override=<name>   Name (CN) expect from server certificate, useful
+                                  in testing
+                                  [Default: ]
+  --no-publish                    Do not publish discovered features to the
+                                  cluster-local Kubernetes API server.
+  --oneshot                       Update once and exit.
+  --sleep-interval=<seconds>      Time to sleep between re-labeling. Non-positive
+                                  value implies no re-labeling (i.e. infinite
+                                  sleep). [Default: 60s]
+  --watch-namespace=<namespace>   Namespace to watch pods for. Use "" for all namespaces.
+  --sysfs=<mountpoint>            Mount point of the sysfs.
+                                  [Default: /host]
+  --kubelet-config-file=<path>    Kubelet config file path.
+                                  [Default: /podresources/config.yaml]
+  --podresources-socket=<path>    Pod Resource Socket path to use.
+                                  [Default: /podresources/kubelet.sock]
+```
+
+**NOTE** Some feature sources need certain directories and/or files from the
+host mounted inside the NFD container. Thus, you need to provide Docker with the
+correct `--volume` options in order for them to work correctly when run
+stand-alone directly with `docker run`. See the
+[template spec](https://github.com/kubernetes-sigs/node-feature-discovery/blob/{{ site.release }}/nfd-worker-daemonset.yaml.template)
+for up-to-date information about the required volume mounts.
+
 ## Documentation
 
 All documentation resides under the

--- a/docs/advanced/topology-updater-commandline-reference.md
+++ b/docs/advanced/topology-updater-commandline-reference.md
@@ -1,0 +1,199 @@
+---
+title: "Topology Updater Cmdline Reference"
+layout: default
+sort: 3
+---
+
+# NFD-Topology-Updater Commandline Flags
+{: .no_toc }
+
+## Table of Contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+To quickly view available command line flags execute `nfd-topology-updater --help`.
+In a docker container:
+
+```bash
+docker run gcr.io/k8s-staging-nfd/node-feature-discovery:master nfd-topology-updater --help
+```
+
+### -h, --help
+
+Print usage and exit.
+
+### --version
+
+Print version and exit.
+
+### --server
+
+The `--server` flag specifies the address of the nfd-master endpoint where to
+connect to.
+
+Default: localhost:8080
+
+Example:
+
+```bash
+nfd-topology-updater --server=nfd-master.nfd.svc.cluster.local:443
+```
+
+### --ca-file
+
+The `--ca-file` is one of the three flags (together with `--cert-file` and
+`--key-file`) controlling the mutual TLS authentication on the topology-updater side.
+This flag specifies the TLS root certificate that is used for verifying the
+authenticity of nfd-master.
+
+Default: *empty*
+
+Note: Must be specified together with `--cert-file` and `--key-file`
+
+Example:
+
+```bash
+nfd-topology-updater --ca-file=/opt/nfd/ca.crt --cert-file=/opt/nfd/updater.crt --key-file=/opt/nfd/updater.key
+```
+
+### --cert-file
+
+The `--cert-file` is one of the three flags (together with `--ca-file` and
+`--key-file`) controlling mutual TLS authentication on the topology-updater side. This
+flag specifies the TLS certificate presented for authenticating outgoing
+requests.
+
+Default: *empty*
+
+Note: Must be specified together with `--ca-file` and `--key-file`
+
+Example:
+
+```bash
+nfd-topology-updater --cert-file=/opt/nfd/updater.crt --key-file=/opt/nfd/updater.key --ca-file=/opt/nfd/ca.crt
+```
+
+### --key-file
+
+The `--key-file` is one of the three flags (together with `--ca-file` and
+`--cert-file`) controlling the mutual TLS authentication on the topology-updater side.
+This flag specifies the private key corresponding the given certificate file
+(`--cert-file`) that is used for authenticating outgoing requests.
+
+Default: *empty*
+
+Note: Must be specified together with `--cert-file` and `--ca-file`
+
+Example:
+
+```bash
+nfd-topology-updater --key-file=/opt/nfd/updater.key --cert-file=/opt/nfd/updater.crt --ca-file=/opt/nfd/ca.crt
+```
+
+### --server-name-override
+
+The `--server-name-override` flag specifies the common name (CN) which to
+expect from the nfd-master TLS certificate. This flag is mostly intended for
+development and debugging purposes.
+
+Default: *empty*
+
+Example:
+
+```bash
+nfd-topology-updater --server-name-override=localhost
+```
+
+### --no-publish
+
+The `--no-publish` flag disables all communication with the nfd-master, making
+it a "dry-run" flag for nfd-topology-updater. NFD-Topology-Updater runs resource hardware topology detection normally,
+but no CRD requests are sent to nfd-master.
+
+Default: *false*
+
+Example:
+
+```bash
+nfd-topology-updater --no-publish
+```
+
+### --oneshot
+
+The `--oneshot` flag causes nfd-topology-updater to exit after one pass of resource hardware topology
+detection.
+
+Default: *false*
+
+Example:
+
+```bash
+nfd-topology-updater --oneshot --no-publish
+```
+
+### --sleep-interval
+
+The `--sleep-interval` specifies the interval between resource hardware topology re-examination (and
+CRD updation). A non-positive value implies infinite sleep interval, i.e.
+no re-detection or re-labeling is done.
+
+Default: 60s
+
+Example:
+
+```bash
+nfd-topology-updater --sleep-interval=1h
+```
+
+### --watch-namespace
+
+The `--watch-namespace` specifies the namespace to ensure that resource hardware topology examination
+only happens for the pods running in the specified namespace. Pods  that are not running in the specified
+namespace are not considered during resource accounting. An empty value would mean that all the pods would
+be considered during the accounting process.
+
+Default: *empty*
+
+Example:
+
+```bash
+nfd-topology-updater --watch-namespace=rte
+```
+### --sysfs
+
+The `--sysfs` specifies the root mountpoint that topology-updater uses when looking for information about the host system.
+Default: /host
+
+Example:
+
+```bash
+nfd-topology-updater --sysfs=/host
+```
+### --kubelet-config-file
+
+The `--kubelet-config-file` specifies the path to the Kubelet's configuration file.
+
+Default:  /podresources/config.yaml
+
+Example:
+
+```bash
+nfd-topology-updater --kubelet-config-file=/var/lib/kubelet/config.yaml
+```
+
+### --podresources-socket
+
+The `--podresources-socket` specifies the path to the Unix socket where kubelet exports a gRPC service
+to enable discovery of in-use CPUs and devices, and to provide metadata for them.
+
+Default:  /podresources/kubelet.sock
+
+Example:
+
+```bash
+nfd-topology-updater --podresources-socket=/var/lib/kubelet/pod-resources/kubelet.sock
+```

--- a/docs/advanced/worker-commandline-reference.md
+++ b/docs/advanced/worker-commandline-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Worker Cmdline Reference"
 layout: default
-sort: 3
+sort: 4
 ---
 
 # NFD-Worker Commandline Flags

--- a/docs/advanced/worker-configuration-reference.md
+++ b/docs/advanced/worker-configuration-reference.md
@@ -1,7 +1,7 @@
 ---
 title: "Worker Config Reference"
 layout: default
-sort: 4
+sort: 5
 published: false
 ---
 

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -22,16 +22,25 @@ Deploy nfd-worker as a daemonset
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-worker-daemonset.yaml.template
 ```
 
+Deploy nfd-topology-updater as a daemonset
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/node-feature-discovery/{{ site.release }}/nfd-topology-updater-daemonset.yaml.template
+```
+
 ## Verify
 
 Wait until NFD master and worker are running.
 
 ```bash
 $ kubectl -n node-feature-discovery get ds,deploy
-NAME                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
-daemonset.apps/nfd-worker   3         3         3       3            3           <none>          5s
+NAME                                  DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+daemonset.apps/nfd-topology-updater   2         2         2       2            2           <none>          5s
+daemonset.apps/nfd-worker             2         2         2       2            2           <none>          10s
+
 NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nfd-master   1/1     1            1           17s
+
 ```
 
 Check that NFD feature labels have been created
@@ -45,6 +54,15 @@ $ kubectl get no -o json | jq .items[].metadata.labels
   "feature.node.kubernetes.io/cpu-cpuid.AESNI": "true",
   "feature.node.kubernetes.io/cpu-cpuid.AVX": "true",
 ...
+```
+
+Check that the NodeResourceTopology CRD instances are created
+```bash
+$ kubectl get noderesourcetopologies.topology.node.k8s.io
+NAME                 AGE
+kind-control-plane   23s
+kind-worker          23s
+
 ```
 
 ## Use Node Labels
@@ -76,3 +94,51 @@ $ kubectl get po feature-dependent-pod -o wide
 NAME                    READY   STATUS    RESTARTS   AGE   IP          NODE     NOMINATED NODE   READINESS GATES
 feature-dependent-pod   1/1     Running   0          23s   10.36.0.4   node-2   <none>           <none>
 ```
+
+## Show the CRDs
+
+```bash
+$ kubectl describe noderesourcetopologies.topology.node.k8s.io kind-control-plane
+Name:         kind-control-plane
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+API Version:  topology.node.k8s.io/v1alpha1
+Kind:         NodeResourceTopology
+...
+Topology Policies:
+  single-numa-node
+Zones:
+    Name:             node-0
+    Costs:
+      node-0:  10
+      node-1:  20
+    Resources:
+        Name:         Cpu
+        Allocatable:  3
+        Capacity:     3
+        Name:         vendor/nic1
+        Allocatable:  2
+        Capacity:     2
+        Name:         vendor/nic2
+        Allocatable:  2
+        Capacity:     2
+    Type:             Node
+    Name:             node-1
+    Costs:
+      node-0:  20
+      node-1:  10
+    Resources:
+        Name:         Cpu
+        Allocatable:  4
+        Capacity:     4
+        Name:         vendor/nic1
+        Allocatable:  2
+        Capacity:     2
+        Name:         vendor/nic2
+        Allocatable:  2
+        Capacity:     2
+    Type:             Node
+Events:               <none>
+```
+The CRD instances created can be used to gain insight into the allocatable resources along with the granularity of those resources at a per-zone level (represented by node-0 and node-1 in the above example) or can be used by an external entity (e.g. topology-aware scheduler plugin) to take an action based on the gathered information.


### PR DESCRIPTION
Prior to this feature, NFD consisted of only software components namely
nfd-master and nfd-worker. We have introduced another software component
called nfd-topology-updater.

NFD-Topology-Updater is a daemon responsible for examining allocated resources
on a worker node to account for allocatable resources on a per-zone basis (where
a zone can be a NUMA node). It then communicates the information to nfd-master
which does the CRD creation corresponding to all the nodes in the cluster. One
instance of nfd-topology-updater is supposed to be running on each node of the
cluster.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>