### PR TITLE
WIP: Pull Topology Manager Policy from /configz endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/klauspost/cpuid v1.2.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
+	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
 	github.com/swatisehgal/topologyapi v0.0.0-20201002094043-bc432ffbe41c

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,6 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/fromanirh/ghw v0.0.3 h1:J3UbCrlrIf4sNpWoF1aasijFnSu/TOC7jmBP6f1zpfI=
-github.com/fromanirh/ghw v0.0.3/go.mod h1:QOXppNRCLGYR1H+hu09FxZPqjNt09bqUZUnOL3Rcero=
 github.com/fromanirh/kubernetes v1.18.0-alpha.1.0.20201127133213-6f0bc0d851ab h1:moI7z14IkqFnClt0DP9M7pcYlY/8f/r/lrhcaBD5aQU=
 github.com/fromanirh/kubernetes v1.18.0-alpha.1.0.20201127133213-6f0bc0d851ab/go.mod h1:/xrHGNfoQphtkhZvyd5bA1lRmz+QkDVmBZu+O8QMoek=
 github.com/fromanirh/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20201127133213-6f0bc0d851ab h1:t6dvIjya+kryw71YUtVVWcgEnzu8NPltLUp9wvMKPa0=
@@ -423,7 +421,6 @@ github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
-github.com/jaypipes/ghw v0.6.1/go.mod h1:QOXppNRCLGYR1H+hu09FxZPqjNt09bqUZUnOL3Rcero=
 github.com/jaypipes/ghw v0.6.2-0.20210115144335-efbe6fd4efca h1:pJpwCf7qq33TyKpc39RJzRSWeIntvFPEYPeVlJrOTvc=
 github.com/jaypipes/ghw v0.6.2-0.20210115144335-efbe6fd4efca/go.mod h1:QOXppNRCLGYR1H+hu09FxZPqjNt09bqUZUnOL3Rcero=
 github.com/jaypipes/pcidb v0.5.0 h1:4W5gZ+G7QxydevI8/MmmKdnIPJpURqJ2JNXTzfLxF5c=

--- a/manifests/nfd-daemonset-master-topology-updater.yaml.template
+++ b/manifests/nfd-daemonset-master-topology-updater.yaml.template
@@ -52,6 +52,34 @@ subjects:
     name: nfd-master
     namespace: node-feature-discovery
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+# This ClusterRole needs to access nodes/proxy in order to pull information from kubelets configz endpoint
+  name: configzgetter
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nfd-configz
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: configzgetter
+subjects:
+# Bind here to the default service account for NFD. This should have a separate serviceaccount.
+  - kind: ServiceAccount
+    name: default
+    namespace: node-feature-discovery
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/pkg/kubeconf/kubelet_config_file.go
+++ b/pkg/kubeconf/kubelet_config_file.go
@@ -1,12 +1,24 @@
 package kubeconf
 
 import (
-	"io/ioutil"
-
+	"context"
 	"github.com/ghodss/yaml"
-
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
+
+// configzEndpoint is a struct to allow unmarshalling the TopologyManagerPolicy from the kubelet configz endpoint
+// The endpoint does not return kubeletConfig API object. It contains all the configuration fields without the headers.
+// This is a limitation of the current (1.20) kubelet endpoint. This struct is a minimum wrapper for Topology Policy.
+type configzEndpoint struct {
+	Kubeletconfig struct {
+		TopologyManagerPolicy          string   `json:"topologyManagerPolicy"`
+	} `json:"kubeletconfig"`
+}
 
 // GetKubeletConfigFromLocalFile returns KubeletConfiguration loaded from the node local config
 func GetKubeletConfigFromLocalFile(kubeletConfigPath string) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
@@ -20,4 +32,29 @@ func GetKubeletConfigFromLocalFile(kubeletConfigPath string) (*kubeletconfigv1be
 		return nil, err
 	}
 	return kubeletConfig, nil
+}
+// GetKubeletConfigFromKubeletAPI creates a kubernetes client to pull Topology Manager information on configz
+func GetKubeletConfigFromKubeletAPI(kubeletConfigPath string, nodename string) (*kubeletconfigv1beta1.KubeletConfiguration, error ){
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeletConfigPath)
+	}
+	if err != nil {
+		return nil, err
+	}
+	cl, err  := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	//request here is the same as: curl https://$APISERVER:6443/api/v1/nodes/$NODE_NAME/proxy/configz
+	request := cl.CoreV1().RESTClient().Get().Resource("nodes").Name(nodename).SubResource("proxy").Suffix("configz")
+	kubeletBytes, err := request.DoRaw(context.TODO())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get info from node")
+	}
+	configz := &configzEndpoint{}
+	if err := yaml.Unmarshal(kubeletBytes, configz); err != nil {
+		return nil, err
+	}
+	return &kubeletconfigv1beta1.KubeletConfiguration{TopologyManagerPolicy: configz.Kubeletconfig.TopologyManagerPolicy}, nil
 }

--- a/pkg/resourcemonitor/types.go
+++ b/pkg/resourcemonitor/types.go
@@ -30,6 +30,7 @@ type Args struct {
 	Namespace             string
 	SysfsRoot             string
 	KubeletConfigFile     string
+	KubeConfigFile		  string
 }
 
 type ResourceInfo struct {


### PR DESCRIPTION
This update allows the topology updater to pull its config from the configz endpoint rather than from a kubelet configuration file. I'm looking for feedback as to whether this is the right approach for getting the policy.

There's a number of outstanding issues with this approach in:
1) configz is an unstable and unversioned API. It may move or change or disappear in future.
2) Requires a kubeclient with additional clusterrole permissions to read the endpoint.
3) We're reading this through the API proxy. There might be a way to read directly from kubelet without the API client but I ran into issues with permissions at the endpoint.
4) There is an [proposal to make the configz endpoint more stable](https://docs.google.com/document/d/1kNVSdw7H9EqyvI2BYH4EqwVtcg9bi9ZCPpJs8aKZFmM/edit#heading=h.a14lyh7vivpj) (coming from dynamic kubelet config) but it hasn't seem to move https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/ 

On the other hand there are similar issues with reading the policy from a file right now. The config endpoint is up-to-date while the file might not be, and the configz method can be pre-configured, while users would have to provide their own kubelet config location and understand what it represents.
