### PR TITLE
Expose Topology manager scope

### DIFF
--- a/cmd/nfd-topology-updater/main.go
+++ b/cmd/nfd-topology-updater/main.go
@@ -28,6 +28,7 @@ import (
 	topology "sigs.k8s.io/node-feature-discovery/pkg/nfd-topology-updater"
 	"sigs.k8s.io/node-feature-discovery/pkg/podres"
 	"sigs.k8s.io/node-feature-discovery/pkg/resourcemonitor"
+	"sigs.k8s.io/node-feature-discovery/pkg/topologypolicy"
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
 )
 
@@ -59,9 +60,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("error getting topology Manager Policy: %v", err)
 		}
-		tmPolicy = klConfig.TopologyManagerPolicy
+		tmPolicy = string(topologypolicy.DetectTopologyPolicy(klConfig.TopologyManagerPolicy, klConfig.TopologyManagerScope))
 		log.Printf("Detected kubelet Topology Manager policy %q", tmPolicy)
-	} // Otherwise get TopologyManagerPolicy from configz-endpoint
+	} // Otherwise get topology policy from configz-endpoint
 
 	podResClient, err := podres.GetPodResClient(resourcemonitorArgs.PodResourceSocketPath)
 	if err != nil {

--- a/pkg/nfd-master/nfd-master.go
+++ b/pkg/nfd-master/nfd-master.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/node-feature-discovery/pkg/apihelper"
 	"sigs.k8s.io/node-feature-discovery/pkg/dumpobject"
 	pb "sigs.k8s.io/node-feature-discovery/pkg/labeler"
+	"sigs.k8s.io/node-feature-discovery/pkg/topologypolicy"
 	topologypb "sigs.k8s.io/node-feature-discovery/pkg/topologyupdater"
 	"sigs.k8s.io/node-feature-discovery/pkg/version"
 )
@@ -456,7 +457,7 @@ func (s *nodeTopologyServer) UpdateNodeTopology(c context.Context, r *topologypb
 			stderrLogger.Printf("failed to get Kubelet config: %s", err.Error())
 			return &topologypb.NodeTopologyResponse{}, err
 		}
-		r.TopologyPolicies[0] = kc.TopologyManagerPolicy
+		r.TopologyPolicies[0] = string(topologypolicy.DetectTopologyPolicy(kc.TopologyManagerPolicy, kc.TopologyManagerScope))
 	}
 
 	stdoutLogger.Printf("REQUEST Node: %s NFD-version: %s Topology Policy: %s Zones: %v", r.NodeName, r.NfdVersion, r.TopologyPolicies, dumpobject.DumpObject(r.Zones))

--- a/pkg/topologypolicy/topology-policy.go
+++ b/pkg/topologypolicy/topology-policy.go
@@ -3,9 +3,11 @@ package topologypolicy
 // DetectTopologyPolicy returns TopologyManagerPolicy type which present
 // both Topology manager policy and scope
 func DetectTopologyPolicy(policy string, scope string) TopologyManagerPolicy {
-	switch policy {
+	k8sTmPolicy := K8sTopologyManagerPolicies(policy)
+	k8sTmScope := K8sTopologyManagerScopes(scope)
+	switch k8sTmPolicy {
 	case singleNumaNode:
-		if scope == pod {
+		if k8sTmScope == pod {
 			return SingleNumaPodScope
 		}
 		// default scope for single-numa-node

--- a/pkg/topologypolicy/topology-policy.go
+++ b/pkg/topologypolicy/topology-policy.go
@@ -4,15 +4,15 @@ package topologypolicy
 // both Topology manager policy and scope
 func DetectTopologyPolicy(policy string, scope string) TopologyManagerPolicy {
 	switch policy {
-	case "single-numa-node":
-		if scope == "pod" {
+	case singleNumaNode:
+		if scope == pod {
 			return SingleNumaPodScope
 		}
 		// default scope for single-numa-node
 		return SingleNumaContainerScope
-	case "Restricted":
+	case restricted:
 		return Restricted
-	case "BestEffort":
+	case bestEffort:
 		return BestEffort
 	default:
 		return None

--- a/pkg/topologypolicy/topology-policy.go
+++ b/pkg/topologypolicy/topology-policy.go
@@ -1,0 +1,20 @@
+package topologypolicy
+
+// DetectTopologyPolicy returns TopologyManagerPolicy type which present
+// both Topology manager policy and scope
+func DetectTopologyPolicy(policy string, scope string) TopologyManagerPolicy {
+	switch policy {
+	case "single-numa-node":
+		if scope == "pod" {
+			return SingleNumaPodScope
+		}
+		// default scope for single-numa-node
+		return SingleNumaContainerScope
+	case "Restricted":
+		return Restricted
+	case "BestEffort":
+		return BestEffort
+	default:
+		return None
+	}
+}

--- a/pkg/topologypolicy/types.go
+++ b/pkg/topologypolicy/types.go
@@ -5,21 +5,21 @@ package topologypolicy
 type TopologyManagerPolicy string
 
 const (
-	SingleNumaContainerScope = "SingleNUMANodeContainerLevel"
-	SingleNumaPodScope       = "SingleNUMANodePodLevel"
-	Restricted               = "Restricted"
-	BestEffort               = "BestEffort"
-	None                     = "None"
+	SingleNumaContainerScope TopologyManagerPolicy = "SingleNUMANodeContainerLevel"
+	SingleNumaPodScope       TopologyManagerPolicy = "SingleNUMANodePodLevel"
+	Restricted               TopologyManagerPolicy = "Restricted"
+	BestEffort               TopologyManagerPolicy = "BestEffort"
+	None                     TopologyManagerPolicy = "None"
 )
 
 // K8sTopologyPolicies are resource allocation policies constants
 type K8sTopologyManagerPolicies string
 
 const (
-	singleNumaNode = "single-numa-node"
-	restricted     = "restricted"
-	bestEffort     = "best-effort"
-	none           = "none"
+	singleNumaNode K8sTopologyManagerPolicies = "single-numa-node"
+	restricted     K8sTopologyManagerPolicies = "restricted"
+	bestEffort     K8sTopologyManagerPolicies = "best-effort"
+	none           K8sTopologyManagerPolicies = "none"
 )
 
 // K8sTopologyScopes are constants which defines the granularity
@@ -27,6 +27,6 @@ const (
 type K8sTopologyManagerScopes string
 
 const (
-	pod       = "pod"
-	container = "container"
+	pod       K8sTopologyManagerScopes = "pod"
+	container K8sTopologyManagerScopes = "container"
 )

--- a/pkg/topologypolicy/types.go
+++ b/pkg/topologypolicy/types.go
@@ -1,0 +1,13 @@
+package topologypolicy
+
+// TopologyManagerPolicy constants which represent the current configuration
+// for Topology manager policy and Topology manager scope in Kubelet config
+type TopologyManagerPolicy string
+
+const (
+	SingleNumaContainerScope = "SingleNUMANodeContainerLevel"
+	SingleNumaPodScope       = "SingleNUMANodePodLevel"
+	Restricted               = "Restricted"
+	BestEffort               = "BestEffort"
+	None                     = "None"
+)

--- a/pkg/topologypolicy/types.go
+++ b/pkg/topologypolicy/types.go
@@ -11,3 +11,22 @@ const (
 	BestEffort               = "BestEffort"
 	None                     = "None"
 )
+
+// K8sTopologyPolicies are resource allocation policies constants
+type K8sTopologyManagerPolicies string
+
+const (
+	singleNumaNode = "single-numa-node"
+	restricted     = "restricted"
+	bestEffort     = "best-effort"
+	none           = "none"
+)
+
+// K8sTopologyScopes are constants which defines the granularity
+// at which you would like resource alignment to be performed.
+type K8sTopologyManagerScopes string
+
+const (
+	pod       = "pod"
+	container = "container"
+)

--- a/test/e2e/nfd_topology_updater.go
+++ b/test/e2e/nfd_topology_updater.go
@@ -36,6 +36,7 @@ import (
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
+	"sigs.k8s.io/node-feature-discovery/pkg/topologypolicy"
 	testutils "sigs.k8s.io/node-feature-discovery/test/e2e/utils"
 )
 
@@ -120,10 +121,11 @@ var _ = framework.KubeDescribe("[NFD] Node topology updater", func() {
 					return false
 				}
 
-				if nodeTopology.TopologyPolicies[0] != (*kubeletConfig).TopologyManagerPolicy {
+				tmPolicy := string(topologypolicy.DetectTopologyPolicy((*kubeletConfig).TopologyManagerPolicy, (*kubeletConfig).TopologyManagerScope))
+				if nodeTopology.TopologyPolicies[0] != tmPolicy {
 					framework.Logf("topology policy is different than expected. current: %v, expected: %v",
 						nodeTopology.TopologyPolicies[0],
-						(*kubeletConfig).TopologyManagerPolicy)
+						tmPolicy)
 					return false
 				}
 


### PR DESCRIPTION
As part of the Topology Aware Scheduling improvement, this update captures the configured Topology manager scope in addition to the Topology manager policy.
Based on the value of both attribues a single string will be populated to the CRD.
The string value will be on of the following {SingleNUMANodeContainerLevel, SingleNUMANodePodLevel, BestEffort, Restricted, None}

Signed-off-by: Talor Itzhak <titzhak@redhat.com>