### PR TITLE
Get TopologyManagerPolicy Constants from noderesourcetopology-api Pac…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,9 @@ require (
 	github.com/klauspost/cpuid v1.2.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
+	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.6.1
-	github.com/swatisehgal/topologyapi v0.0.0-20201002094043-bc432ffbe41c
 	github.com/vektra/errors v0.0.0-20140903201135-c64d83aba85a
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
@@ -37,6 +37,7 @@ require (
 // The k8s "sub-"packages do not have 'semver' compatible versions. Thus, we
 // need to override with commits (corresponding their kubernetes-* tags)
 replace (
+	github.com/k8stopologyawareschedwg/noderesourcetopology-api => github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.9-0.20210319150817-4197eab203d5
 	//force version of x/text due CVE-2020-14040
 	golang.org/x/text => golang.org/x/text v0.3.3
 	google.golang.org/grpc => google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.6 h1:0yAWdTOapmVmmsPEEEIzt4F9p37kPuMQ8I6P4GxVZoM=
-github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.6/go.mod h1:zRoCNg6LjSQewUwnpORw1VT9mP0rGNQlYy4WYaGWvHo=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.9-0.20210319150817-4197eab203d5 h1:vthVPYi+0c83pQWl8OPDTdsWY0chIqZZb9fDkqMxhCo=
+github.com/k8stopologyawareschedwg/noderesourcetopology-api v0.0.9-0.20210319150817-4197eab203d5/go.mod h1:zRoCNg6LjSQewUwnpORw1VT9mP0rGNQlYy4WYaGWvHo=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -670,8 +670,6 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/swatisehgal/topologyapi v0.0.0-20201002094043-bc432ffbe41c h1:BoT3ZVd53R7EpqhJHfPPbco31ZYqJsfr6rVu5bVUqnM=
-github.com/swatisehgal/topologyapi v0.0.0-20201002094043-bc432ffbe41c/go.mod h1:9CKMMS83d72bYp2AIc7VSV9acET7rHyBFAnUvdISijI=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thecodeteam/goscaleio v0.1.0 h1:SB5tO98lawC+UK8ds/U2jyfOCH7GTcFztcF5x9gbut4=
@@ -1085,7 +1083,6 @@ k8s.io/mount-utils v0.20.0-beta.2/go.mod h1:Jv9NRZ5L2LF87A17GaGlArD+r3JAJdZFvo4X
 k8s.io/sample-apiserver v0.20.0-beta.2 h1:PalcGiN/FvcUkk3RWzi6/aaQZPc/RoFgZ5NFavaNUIA=
 k8s.io/sample-apiserver v0.20.0-beta.2/go.mod h1:Wc1joHAptwu3b1hA6VtMeC4SUlo7j3rHI77vTuTHRV0=
 k8s.io/system-validators v1.2.0/go.mod h1:bPldcLgkIUK22ALflnsXk8pvkTEndYdNuaHH6gRrl0Q=
-k8s.io/utils v0.0.0-20200720150651-0bdb4ca86cbc/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=

--- a/pkg/topologypolicy/topology-policy.go
+++ b/pkg/topologypolicy/topology-policy.go
@@ -1,22 +1,26 @@
 package topologypolicy
 
+import (
+	v1alpha1 "github.com/k8stopologyawareschedwg/noderesourcetopology-api/pkg/apis/topology/v1alpha1"
+)
+
 // DetectTopologyPolicy returns TopologyManagerPolicy type which present
 // both Topology manager policy and scope
-func DetectTopologyPolicy(policy string, scope string) TopologyManagerPolicy {
+func DetectTopologyPolicy(policy string, scope string) v1alpha1.TopologyManagerPolicy {
 	k8sTmPolicy := K8sTopologyManagerPolicies(policy)
 	k8sTmScope := K8sTopologyManagerScopes(scope)
 	switch k8sTmPolicy {
 	case singleNumaNode:
 		if k8sTmScope == pod {
-			return SingleNumaPodScope
+			return v1alpha1.SingleNUMANodePodLevel
 		}
 		// default scope for single-numa-node
-		return SingleNumaContainerScope
+		return v1alpha1.SingleNUMANodeContainerLevel
 	case restricted:
-		return Restricted
+		return v1alpha1.Restricted
 	case bestEffort:
-		return BestEffort
+		return v1alpha1.BestEffort
 	default:
-		return None
+		return v1alpha1.None
 	}
 }

--- a/pkg/topologypolicy/types.go
+++ b/pkg/topologypolicy/types.go
@@ -1,17 +1,5 @@
 package topologypolicy
 
-// TopologyManagerPolicy constants which represent the current configuration
-// for Topology manager policy and Topology manager scope in Kubelet config
-type TopologyManagerPolicy string
-
-const (
-	SingleNumaContainerScope TopologyManagerPolicy = "SingleNUMANodeContainerLevel"
-	SingleNumaPodScope       TopologyManagerPolicy = "SingleNUMANodePodLevel"
-	Restricted               TopologyManagerPolicy = "Restricted"
-	BestEffort               TopologyManagerPolicy = "BestEffort"
-	None                     TopologyManagerPolicy = "None"
-)
-
 // K8sTopologyPolicies are resource allocation policies constants
 type K8sTopologyManagerPolicies string
 


### PR DESCRIPTION
This update allow us to get all TopologyManagerPolicy constants from centralized place

Signed-off-by: Talor Itzhak <titzhak@redhat.com>